### PR TITLE
vf-mergeにマージリクエスト機能を追加

### DIFF
--- a/docs/plans/2026-03-16-vf-merge-request-design.md
+++ b/docs/plans/2026-03-16-vf-merge-request-design.md
@@ -1,0 +1,43 @@
+# vf-merge マージリクエスト機能追加 設計ドキュメント
+
+## 概要
+
+vf-mergeスキルに「マージリクエスト」ステップを追加する。
+クリーンアップの前に、未マージのvibe-flow PRを検出し、人間の個別承認を経て`gh pr merge`でマージする。
+
+## 変更対象
+
+- `skills/vf-merge/SKILL.md`
+
+## 設計
+
+### 新ステップ: Step 0 — マージリクエスト
+
+既存のStep 1（クリーンアップ対象の特定）の前に挿入する。
+
+**フロー:**
+1. `gh pr list --label vibe-flow --state open`でオープン中のvibe-flow PRを取得
+2. オープンPRがない場合はスキップして既存フローへ
+3. 各PRについて人間に個別確認:「PR #N: [タイトル] をマージしますか？」
+4. 承認されたPRを`gh pr merge <number> --merge --delete-branch`でマージ
+5. 全マージ完了後、既存のクリーンアップフロー（Step 1〜5）に進む
+
+### 既存フローへの影響
+
+- Step 1〜5は変更なし
+- マージ時に`--delete-branch`でリモートブランチが削除されるため、Step 3のリモートブランチ削除は重複チェックが必要
+
+## Issue Breakdown
+
+### Issue 1: vf-merge SKILL.mdにマージリクエストステップを追加
+**Description:** vf-mergeスキルのThe Processセクションに「Step 0: マージリクエスト」を追加。オープン中のvibe-flow PRを検出し、個別承認を経てgh pr mergeで自動マージする機能を記述する。
+**Acceptance Criteria:**
+- [ ] SKILL.mdに「Step 0: マージリクエスト」セクションが追加されている
+- [ ] オープンPRの検出手順が記載されている
+- [ ] 個別承認フローが記載されている
+- [ ] `gh pr merge --merge --delete-branch`でのマージ手順が記載されている
+- [ ] オープンPRがない場合のスキップ条件が記載されている
+
+## Execution Order
+
+`[#3]`

--- a/skills/vf-merge/SKILL.md
+++ b/skills/vf-merge/SKILL.md
@@ -13,6 +13,43 @@ Clean up all resources created during a vibe-flow cycle and sync the local envir
 
 ## The Process
 
+### 0. Merge Request
+
+Before cleanup, check for open vibe-flow PRs that need merging.
+
+```bash
+# List open PRs with vibe-flow label
+gh pr list --label vibe-flow --state open --json number,title,headRefName
+```
+
+**If no open PRs:** Skip to Step 1.
+
+**If open PRs exist:**
+
+For each open PR, ask the human for approval individually:
+
+```
+Open vibe-flow PRs found:
+
+PR #15: Add auth endpoint (branch: vf/12-add-auth)
+  → Merge this PR? [Yes / No / Skip]
+```
+
+For each approved PR, merge via gh CLI:
+
+```bash
+gh pr merge <number> --merge --delete-branch
+```
+
+- `--merge`: merge commit strategy
+- `--delete-branch`: automatically delete the remote branch after merge
+
+After all approved PRs are merged (or skipped), proceed to Step 1.
+
+**Error handling:**
+- If merge fails due to conflicts, report the conflict and ask the human to resolve manually
+- If merge fails due to required checks, report the status and suggest waiting
+
 ### 1. Identify Cleanup Targets
 
 Find all merged vibe-flow PRs and their associated resources:
@@ -76,9 +113,9 @@ git worktree remove "${REPO_ROOT}/.worktrees/vf/13-add-api" --force
 git branch -d vf/12-add-auth
 git branch -d vf/13-add-api
 
-# Delete remote branches
-git push origin --delete vf/12-add-auth
-git push origin --delete vf/13-add-api
+# Delete remote branches (skip if already deleted by --delete-branch in Step 0)
+git push origin --delete vf/12-add-auth 2>/dev/null || true
+git push origin --delete vf/13-add-api 2>/dev/null || true
 
 # Handle design documents (based on user choice)
 # Option 1: Delete


### PR DESCRIPTION
## Summary

- vf-mergeスキルに「Step 0: マージリクエスト」を追加
- クリーンアップ前にオープン中のvibe-flow PRを検出
- 人間に個別承認を求め、承認されたPRを`gh pr merge --merge --delete-branch`でマージ
- コンフリクトやチェック失敗時のエラーハンドリングも記載

Closes #3

## Test plan

- [ ] SKILL.mdに「Step 0: マージリクエスト」セクションが存在すること
- [ ] オープンPR検出の`gh pr list`コマンドが記載されていること
- [ ] 個別承認フローが記載されていること
- [ ] `gh pr merge --merge --delete-branch`コマンドが記載されていること
- [ ] オープンPRがない場合のスキップ条件が記載されていること
- [ ] Step 3のリモートブランチ削除が重複時にエラーにならないこと

---
*Generated by github-vibe-flow*