### PR TITLE
fix: Agent実行時の観測性を改善

### DIFF
--- a/skills/vf-execute/SKILL.md
+++ b/skills/vf-execute/SKILL.md
@@ -70,21 +70,19 @@ BRANCH_NAME="vf/${ISSUE_NUM}-${ISSUE_TITLE_SLUG}"
 # worktreeを作成
 git worktree add "${REPO_ROOT}/.worktrees/${BRANCH_NAME}" -b "${BRANCH_NAME}"
 
-# 新しいtmuxペインでClaude Codeを起動
-tmux split-window -t vibe-flow -h
-tmux send-keys -t vibe-flow "cd ${REPO_ROOT}/.worktrees/${BRANCH_NAME} && claude --print --dangerously-skip-permissions -p 'AGENT_PROMPT_HERE'" Enter
-
-# 識別用にペイン名を設定
-tmux select-pane -T "vf-${ISSUE_NUM}"
+# 新しいtmuxウィンドウでClaude Codeを起動（ペインではなくウィンドウを使い、各Agentの進捗を個別に確認可能にする）
+tmux new-window -n "vf-${ISSUE_NUM}" "cd ${REPO_ROOT}/.worktrees/${BRANCH_NAME} && claude --dangerously-skip-permissions -p 'AGENT_PROMPT_HERE'"
 ```
+
+**注意:** `--print` は使用しない。`--print` は全出力をバッファして完了時に一括表示するため、実行中の進捗が見えなくなる。`--print` なしであればTUIがリアルタイムで表示され、ユーザーが `tmux select-window` で各Agentの進捗を確認できる。
 
 ### 6. 進捗のモニタリング
 
-tmuxペインのアクティビティで各Agentのステータスを追跡する:
+各Agentのウィンドウが残っているかで完了を検知する:
 
 ```bash
-# ペインのプロセスが実行中か確認
-tmux list-panes -t vibe-flow -F '#{pane_title} #{pane_pid} #{pane_current_command}'
+# 各Agentウィンドウの生存確認（ウィンドウが閉じれば完了）
+tmux list-windows -F '#{window_name} #{window_active}'
 ```
 
 シリアルステップの完了（またはパラレルグループの全項目完了）を検知したら、次のステップに進む。

--- a/skills/vf-execute/agent-prompt.md
+++ b/skills/vf-execute/agent-prompt.md
@@ -5,7 +5,7 @@
 プレースホルダー（ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, ACCEPTANCE_CRITERIA, WORKTREE_PATH, BRANCH_NAME）を実際の値に置換すること。
 
 ```
-claude --print --dangerously-skip-permissions -p "
+claude --dangerously-skip-permissions -p "
 You are working on GitHub Issue ISSUE_NUMBER: ISSUE_TITLE
 
 ## Issue の説明

--- a/skills/vf-monitor/SKILL.md
+++ b/skills/vf-monitor/SKILL.md
@@ -57,12 +57,11 @@ INTERVAL=${1:-30}  # 秒
      fi
      ```
    - `./review-responder-prompt.md` テンプレートからプロンプトを構築する
-   - 新しいtmuxペインでClaude Codeを起動する:
+   - 新しいtmuxウィンドウでClaude Codeを起動する:
      ```bash
-     tmux split-window -t vibe-flow -h
-     tmux send-keys -t vibe-flow "cd ${WORKTREE_PATH} && claude --print --dangerously-skip-permissions -p 'RESPONDER_PROMPT'" Enter
-     tmux select-pane -T "vf-review-${PR_NUMBER}"
+     tmux new-window -n "vf-review-${PR_NUMBER}" "cd ${WORKTREE_PATH} && claude --dangerously-skip-permissions -p 'RESPONDER_PROMPT'"
      ```
+     **注意:** `--print` は使用しない。TUIのリアルタイム表示でユーザーが進捗を確認できるようにする。
    - このPRの最終確認タイムスタンプを更新する
 
 4. **終了条件の確認:**


### PR DESCRIPTION
## Summary

- `--print` フラグを廃止し、AgentのTUIをリアルタイムで表示可能にした
- `tmux split-window`（ペイン）から `tmux new-window`（ウィンドウ）に変更し、各Agentに独立したウィンドウを割り当て
- vf-execute, vf-monitor の両スキルと agent-prompt.md を更新

## Test plan

- [ ] vf-execute で複数Issueを実行し、各tmuxウィンドウでAgentの進捗がリアルタイムに見えることを確認
- [ ] Agent完了後にウィンドウが閉じることを確認
- [ ] vf-monitor のレスポンダーAgentも同様にウィンドウで起動されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)